### PR TITLE
Fix matchmaking

### DIFF
--- a/commands/viewfixtures.js
+++ b/commands/viewfixtures.js
@@ -18,11 +18,11 @@ module.exports = class ViewfixturesCommand extends BaseCommand {
 			.setColor('#0099ff')
 			.setTitle('King of Ones Fixtures')
 
+		let fixtureString = '';
 		for (let fixture of fixtures) {
-			fixtureEmbed.addField('Attacker', fixture.attacker, true);
-			fixtureEmbed.addField('---', 'vs', true);
-			fixtureEmbed.addField('Defender', fixture.defender, true);
+			fixtureString += `${fixture.attacker.toUpperCase()} attacking ${fixture.defender.toUpperCase()}\n\n`;
 		}
+		fixtureEmbed.setDescription(fixtureString);
 
 		message.channel.send(fixtureEmbed);
 	}

--- a/fixturegen.js
+++ b/fixturegen.js
@@ -31,12 +31,12 @@ fixturegen.generateFixtures = async () => {
 	let bestScore = _scoreFixtures(bestFixtures, playerList, matchList);
 	let swapCount = 0;
 
-	while (swapCount < 500) {
+	while (swapCount < 1000) {
 		const newFixtures = _swapTwoInFixtureList(bestFixtures);
 		const newScore = _scoreFixtures(newFixtures, playerList, matchList);
 		if (newScore < bestScore) {
 			bestScore = newScore;
-			bestFixtures = newFixtures;
+			bestFixtures = JSON.parse(JSON.stringify(newFixtures));
 			swapCount = 0;
 		} else {
 			swapCount++;
@@ -77,7 +77,7 @@ _scoreFixtures = (fixtureList, playerList, matchList) => {
 }
 
 _swapTwoInFixtureList = (fixtureList) => {
-	let newFixtureList = fixtureList.slice();
+	let newFixtureList = JSON.parse(JSON.stringify(fixtureList));
 	const match1 = Math.floor(Math.random() * fixtureList.length);
 	const player1 = Math.floor(Math.random() * 2);
 	const name1 = fixtureList[match1][player1];


### PR DESCRIPTION
Fix the matchmaking algorithm implementation to not give REALLY unbalanced matches, and fix the viewfixtures command so that it shows all of the fixtures.

 - Increase the swap limit of the hillclimb up to 1000 from 500
 - Deep-clone the fixtures array in generation so that it works as intended rather than mutating further and further from the best array with every unsuccessful run.
   - The score of a generated fixture array seems to have dropped from about 150ish to about 20ish

 - viewfixtures wasn't showing all matches it used 3 embed fields per game, and discord limits the number of embed fields. New functionality is to construct one string containing all the matches and set it as the embed description.