### PR TITLE
Use @s rather than nicknames when reporting

### DIFF
--- a/commands/report.js
+++ b/commands/report.js
@@ -8,9 +8,9 @@ module.exports = class ReportCommand extends BaseCommand {
 		super('Report', {
 			description: 'Report the result of a fixture',
 			args: {
-				attacker: 'The player who was lower on the leaderboard, or the unrated player',
-				defender: 'The player who was higher on the leaderboard, or the already existing player',
-				winner: 'The player who WON the game'
+				attacker: '@mention the player who was lower on the leaderboard, or the unrated player',
+				defender: '@mention the player who was higher on the leaderboard, or the already existing player',
+				winner: '@mention the player who WON the game'
 			}
 		});
 	}

--- a/commands/report.js
+++ b/commands/report.js
@@ -16,10 +16,11 @@ module.exports = class ReportCommand extends BaseCommand {
 	}
 
 	async execute(message, args) {
-		const attacker = args[0].toLowerCase();
-		const defender = args[1].toLowerCase();
-		const winner = args[2].toLowerCase();
-		const reporterName = message.member.displayName.toLowerCase();
+		const attacker = await firebase.getPlayerNameById(args[0].match(/[0-9]+/g)[0]);
+		const defender = await firebase.getPlayerNameById(args[1].match(/[0-9]+/g)[0]);
+		const winner = await firebase.getPlayerNameById(args[2].match(/[0-9]+/g)[0]);
+		const reporterName = await firebase.getPlayerNameById(message.member.id);
+
 		let confirmer = '';
 
 		if (reporterName === attacker) {

--- a/firebase.js
+++ b/firebase.js
@@ -226,4 +226,21 @@ firebase.updateStandings = async (match) => {
 	}
 };
 
+firebase.getPlayerNameById = async id => {
+	let playerName = '';
+	const playersCollectionRef = db.collection('players')
+		.where('id', '==', id);
+
+	await playersCollectionRef.get()
+		.then(snapshot => {
+			snapshot.forEach(doc => {
+				playerName = doc.id;
+			});
+		})
+		.catch(e => {
+			console.log('Error fetching documents', e);
+		});
+	return playerName;
+}
+
 module.exports = firebase;


### PR DESCRIPTION
 - Add a function to firebase.js to get a player's internal nickname from their discord id
 - report command now uses this and so gets done with @s rather than with the nicknames
 - report command help now says you have to @ the person